### PR TITLE
Call compact on translations.keys to fix calling to_sym on nil

### DIFF
--- a/lib/rails_admin_globalize_field.rb
+++ b/lib/rails_admin_globalize_field.rb
@@ -45,7 +45,7 @@ module RailsAdmin
             return @translations if @translations && !reset_cache
 
             translations = @bindings[:object].translations_by_locale
-            new_locales = available_locales - translations.keys.map(&:to_sym)
+            new_locales = available_locales - translations.keys.compact.map(&:to_sym)
 
             new_locales.map do |locale|
               translations[locale] = @bindings[:object].translations.new({ locale: locale })


### PR DESCRIPTION
This should fix #10. I reproduced it by attempting to save my `Page` model translations. Here's what my model looks like:

```
class Page < ActiveRecord::Base
  has_many :statistics

  translates :hero_title, :hero_subtitle
  accepts_nested_attributes_for :translations, allow_destroy: true
end
```

It looks like this error occurs when there are no other `translations` for other locales besides the default. Once the translation for the new locale is added, the error isn't thrown.