### PR TITLE
Parameterize model name to support namespaced models

### DIFF
--- a/app/views/rails_admin/main/_form_globalize_tabs.html.haml
+++ b/app/views/rails_admin/main/_form_globalize_tabs.html.haml
@@ -1,5 +1,5 @@
 - field.translations(true) # fetch translations and memoize them
-- key = field.abstract_model.model_name.downcase
+- key = field.abstract_model.model_name.parameterize
 
 .controls
   .globalize-errors


### PR DESCRIPTION
Parameterize model name since namespaced models like `Piggybak::Sellable` generate data-target `.localized-pane-en-piggybak::sellable-1:first` which is not a valid JS expression