### PR TITLE
Fixed bug when creating new translations

### DIFF
--- a/lib/rails_admin_globalize_field.rb
+++ b/lib/rails_admin_globalize_field.rb
@@ -45,10 +45,10 @@ module RailsAdmin
             return @translations if @translations && !reset_cache
 
             translations = @bindings[:object].translations_by_locale
-            new_locales = available_locales - translations.keys.map(&:to_sym)
+            new_locales = available_locales
 
             new_locales.map do |locale|
-              translations[locale] = @bindings[:object].translations.new({ locale: locale })
+              translations[locale] ||= @bindings[:object].translations.new({ locale: locale })
             end
 
             @translations = translations


### PR DESCRIPTION
Hi

This PR fixes a bug that was causing the lib not to show existing translations but to clear them, neither when creating new model instances nor when editing an existing one.