### PR TITLE
Update dependencies for Globalize 5 and Rails 4.2

### DIFF
--- a/rails_admin_globalize_field.gemspec
+++ b/rails_admin_globalize_field.gemspec
@@ -18,11 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 4.0", '< 4.2'
+  spec.add_dependency "rails", ">= 4.2"
   spec.add_dependency 'rails_admin', '>= 0.6.2'
 
-  # TODO: uncomment later, when globalize3 rails4 branch would be commited to rubygems
-  spec.add_dependency 'globalize', '>= 4.0', '< 5.0'
+  spec.add_dependency 'globalize', '>= 5.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Addressing issue #17, this commit just updates the dependency version to Globalize 5 and Rails 4.2. Functionality continues to work for me.