### PR TITLE
Pass field object instead of field.name

### DIFF
--- a/app/views/rails_admin/main/_form_globalize_tabs.html.haml
+++ b/app/views/rails_admin/main/_form_globalize_tabs.html.haml
@@ -14,6 +14,6 @@
     - klass = "localized-pane-#{locale}-#{key}-#{form.object.id}"
     = form.fields_for field.name, field.translations[locale], wrapper: false do |nested_form|
       .fields.tab-pane{ class: "#{klass} #{'active' if locale == field.current_locale}" }
-        = nested_form.generate({:action => :nested, :model_config => field.associated_model_config, :nested_in => field.name })
+        = nested_form.generate({:action => :nested, :model_config => field.associated_model_config, :nested_in => field })
 .globalize-help
   = form.help_for(field)


### PR DESCRIPTION
Due to passing field.name in the following snippet, it was passing the name just but the receiver is expecting the field object and trying to call field.name. This fix will make the it compatible with the rails_admin latest version. 

```ruby
 nested_form.generate({:action => :nested, :model_config => field.associated_model_config, :nested_in => field })
```